### PR TITLE
Add Migrate a Site document link

### DIFF
--- a/daniel-v2/get-started/migrating-site.md
+++ b/daniel-v2/get-started/migrating-site.md
@@ -1,1 +1,4 @@
-migrating-site.md
+---
+Support doc: https://wordpress.com/support/import/import-an-entire-wordpress-site/
+---
+# Migrate an Existing Site


### PR DESCRIPTION
The content for `Migrate a Site` can be taken from the existing [Support docs](https://wordpress.com/support/import/import-an-entire-wordpress-site/)

**Notes:**

- The following project [Project Thread: Site Migration i1](https://serenityp2.wordpress.com/2024/02/16/project-thread-site-migration-i1/) will create a Tool for Migration that is designed to improve Migrations, but it is currently In Progress.
- The manual migration section is **not** covered by this content. I have tried the manual migration with no luck, I would need some support for the `manual migration` content.

cc: @danielbachhuber 