### PR TITLE
Add "Deploy From GitHub Workflow" document link

### DIFF
--- a/daniel-v2/README.md
+++ b/daniel-v2/README.md
@@ -16,6 +16,7 @@
   - ✅✨ [SSH/SFTP](https://wpdeveloperstaging.wordpress.com/docs/developer-tools/ssh-sftp/)
   - ✅✨ [Database Access](https://wpdeveloperstaging.wordpress.com/docs/developer-tools/database-access/)
   - ✅✨ [Web Server Settings](https://wpdeveloperstaging.wordpress.com/docs/developer-tools/web-server-settings/)
+  - 🚧 GitHub deployments
   - [REST API](https://developer.wordpress.com/docs/api/)
 - Site Performance
   - ✅✨ [Site Accelerator CDN](https://wpdeveloperstaging.wordpress.com/docs/site-performance/site-accelerator-cdn/)

--- a/daniel-v2/developer-tools/github-deployments.md
+++ b/daniel-v2/developer-tools/github-deployments.md
@@ -1,0 +1,4 @@
+---
+Support doc: https://wordpress.com/support/deploy-from-github-workflow/
+---
+# Deploy From GitHub Workflow


### PR DESCRIPTION
The content for deploying from GitHub can be taken from the existing [Support docs](https://wordpress.com/support/deploy-from-github-workflow/)

We also have a project thread aiming to improve GitHub deployments: pet6gk-SS-p2 I think we can use the existing support doc as a starting point, and update it once the project is completed.

cc: @danielbachhuber @alexapeduzzi 